### PR TITLE
Add prompt manager PWA

### DIFF
--- a/prompt-pwa/app.js
+++ b/prompt-pwa/app.js
@@ -1,0 +1,53 @@
+if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+        navigator.serviceWorker.register('sw.js');
+    });
+}
+
+function loadPrompts() {
+    return JSON.parse(localStorage.getItem('prompts') || '[]');
+}
+
+function savePrompts(prompts) {
+    localStorage.setItem('prompts', JSON.stringify(prompts));
+}
+
+function renderPrompts() {
+    const list = document.getElementById('prompt-list');
+    list.innerHTML = '';
+    loadPrompts().forEach((prompt, index) => {
+        const li = document.createElement('li');
+        li.textContent = prompt;
+
+        const copyBtn = document.createElement('button');
+        copyBtn.textContent = 'Copier';
+        copyBtn.addEventListener('click', () => navigator.clipboard.writeText(prompt));
+
+        const deleteBtn = document.createElement('button');
+        deleteBtn.textContent = 'Supprimer';
+        deleteBtn.addEventListener('click', () => {
+            const prompts = loadPrompts();
+            prompts.splice(index, 1);
+            savePrompts(prompts);
+            renderPrompts();
+        });
+
+        li.append(' ', copyBtn, ' ', deleteBtn);
+        list.appendChild(li);
+    });
+}
+
+document.getElementById('prompt-form').addEventListener('submit', e => {
+    e.preventDefault();
+    const input = document.getElementById('prompt-input');
+    const value = input.value.trim();
+    if (value) {
+        const prompts = loadPrompts();
+        prompts.push(value);
+        savePrompts(prompts);
+        input.value = '';
+        renderPrompts();
+    }
+});
+
+renderPrompts();

--- a/prompt-pwa/app.js
+++ b/prompt-pwa/app.js
@@ -5,7 +5,11 @@ if ('serviceWorker' in navigator) {
 }
 
 function loadPrompts() {
-    return JSON.parse(localStorage.getItem('prompts') || '[]');
+    try {
+        return JSON.parse(localStorage.getItem('prompts')) || [];
+    } catch {
+        return [];
+    }
 }
 
 function savePrompts(prompts) {
@@ -17,7 +21,15 @@ function renderPrompts() {
     list.innerHTML = '';
     loadPrompts().forEach((prompt, index) => {
         const li = document.createElement('li');
-        li.textContent = prompt;
+        li.className = 'prompt-item';
+
+        const text = document.createElement('span');
+        text.className = 'prompt-text';
+        text.textContent = prompt;
+        text.addEventListener('click', () => navigator.clipboard.writeText(prompt));
+
+        const actions = document.createElement('span');
+        actions.className = 'prompt-actions';
 
         const copyBtn = document.createElement('button');
         copyBtn.textContent = 'Copier';
@@ -32,7 +44,8 @@ function renderPrompts() {
             renderPrompts();
         });
 
-        li.append(' ', copyBtn, ' ', deleteBtn);
+        actions.append(copyBtn, deleteBtn);
+        li.append(text, actions);
         list.appendChild(li);
     });
 }
@@ -43,7 +56,7 @@ document.getElementById('prompt-form').addEventListener('submit', e => {
     const value = input.value.trim();
     if (value) {
         const prompts = loadPrompts();
-        prompts.push(value);
+        prompts.unshift(value);
         savePrompts(prompts);
         input.value = '';
         renderPrompts();

--- a/prompt-pwa/index.html
+++ b/prompt-pwa/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Prompt Manager</title>
+    <link rel="manifest" href="manifest.json">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Prompt Manager</h1>
+    <form id="prompt-form">
+        <input type="text" id="prompt-input" placeholder="Nouveau prompt">
+        <button type="submit">Ajouter</button>
+    </form>
+    <ul id="prompt-list"></ul>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/prompt-pwa/index.html
+++ b/prompt-pwa/index.html
@@ -8,12 +8,16 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <h1>Prompt Manager</h1>
-    <form id="prompt-form">
-        <input type="text" id="prompt-input" placeholder="Nouveau prompt">
-        <button type="submit">Ajouter</button>
-    </form>
-    <ul id="prompt-list"></ul>
+    <header>
+        <h1>Prompt Manager</h1>
+    </header>
+    <main class="container">
+        <form id="prompt-form">
+            <textarea id="prompt-input" placeholder="Votre nouveau prompt"></textarea>
+            <button type="submit">Ajouter</button>
+        </form>
+        <ul id="prompt-list" class="prompt-list"></ul>
+    </main>
     <script src="app.js"></script>
 </body>
 </html>

--- a/prompt-pwa/manifest.json
+++ b/prompt-pwa/manifest.json
@@ -1,0 +1,20 @@
+{
+    "name": "Prompt Manager",
+    "short_name": "Prompts",
+    "start_url": "./index.html",
+    "display": "standalone",
+    "background_color": "#ffffff",
+    "theme_color": "#3f51b5",
+    "icons": [
+        {
+            "src": "../icons/icon-192x192.png",
+            "sizes": "192x192",
+            "type": "image/png"
+        },
+        {
+            "src": "../icons/icon-512x512.png",
+            "sizes": "512x512",
+            "type": "image/png"
+        }
+    ]
+}

--- a/prompt-pwa/style.css
+++ b/prompt-pwa/style.css
@@ -1,24 +1,55 @@
 body {
     font-family: sans-serif;
+    margin: 0;
+    padding: 1rem;
+    background: #f0f0f0;
+}
+
+header {
+    text-align: center;
+    margin-bottom: 1rem;
+}
+
+.container {
     max-width: 600px;
     margin: auto;
+    background: #fff;
     padding: 1rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
 form {
     display: flex;
+    flex-direction: column;
     gap: 0.5rem;
     margin-bottom: 1rem;
 }
 
-ul {
+textarea {
+    resize: vertical;
+    min-height: 3rem;
+    padding: 0.5rem;
+}
+
+.prompt-list {
     list-style: none;
     padding: 0;
 }
 
-li {
+.prompt-item {
     display: flex;
     align-items: center;
-    margin-bottom: 0.5rem;
-    gap: 0.5rem;
+    justify-content: space-between;
+    padding: 0.5rem;
+    border-bottom: 1px solid #ddd;
+}
+
+.prompt-text {
+    flex: 1;
+    margin-right: 0.5rem;
+}
+
+.prompt-actions button {
+    margin-left: 0.25rem;
 }

--- a/prompt-pwa/style.css
+++ b/prompt-pwa/style.css
@@ -1,0 +1,24 @@
+body {
+    font-family: sans-serif;
+    max-width: 600px;
+    margin: auto;
+    padding: 1rem;
+}
+
+form {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+ul {
+    list-style: none;
+    padding: 0;
+}
+
+li {
+    display: flex;
+    align-items: center;
+    margin-bottom: 0.5rem;
+    gap: 0.5rem;
+}

--- a/prompt-pwa/sw.js
+++ b/prompt-pwa/sw.js
@@ -1,0 +1,33 @@
+const CACHE_NAME = 'prompt-manager-v1';
+const ASSETS = [
+  './',
+  './index.html',
+  './style.css',
+  './app.js',
+  './manifest.json',
+  '../icons/icon-192x192.png',
+  '../icons/icon-512x512.png'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(names =>
+      Promise.all(
+        names.filter(name => name !== CACHE_NAME).map(name => caches.delete(name))
+      )
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- add `prompt-pwa` mini application
- implement prompt storage with localStorage and simple UI
- include manifest and service worker for PWA functionality

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840a31fa938832e8b4c23d4d7b2bc5b